### PR TITLE
improve remote debugging host

### DIFF
--- a/background.js
+++ b/background.js
@@ -30,6 +30,7 @@ ngApp
         const UNINSTALL_URL = "http://june07.com/uninstall";
         const UPTIME_CHECK_RESOLUTION = 1000; // Check every second
         const DEVEL = false;
+        const IP_PATTERN = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/;
 
         $scope.loaded = Date.now();
         $scope.timerUptime= 0;
@@ -122,10 +123,12 @@ ngApp
                                 .then(function openDevToolsFrontend(json) {
                                     if (!json.data[0].devtoolsFrontendUrl) return callback(chrome.i18n.getMessage("errMsg7", [host, port]));
                                     var url = json.data[0].devtoolsFrontendUrl
-                                    .replace("127.0.0.1:9229", host + ":" + port)
-                                        .replace("localhost:9229", host + ":" + port)
-                                        .replace("127.0.0.1:" + port, host + ":" + port) // In the event that remote debugging is being used and the infoUrl port (by default 80) is not forwarded.
+                                    var remoteIP = url.match(IP_PATTERN)[0];
+                                    url = url
+                                        .replace("localhost:9229", host + ":" + port) // When localhost is being used, set the given host and port
                                         .replace("localhost:" + port, host + ":" + port)  // A check for just the port change must be made.
+                                        .replace(remoteIP + ":9229", host + ":" + port) // In the event that remote debugging is being used and the infoUrl port (by default 80) is not forwarded.
+                                        .replace(remoteIP + ":" + port, host + ":" + port) // A check for just the port change must be made.
                                     if ($scope.settings.localDevTools)
                                         url = url.replace('https://chrome-devtools-frontend.appspot.com', 'chrome-devtools://devtools/remote');
                                     var websocketId = json.data[0].id;

--- a/background.js
+++ b/background.js
@@ -30,7 +30,7 @@ ngApp
         const UNINSTALL_URL = "http://june07.com/uninstall";
         const UPTIME_CHECK_RESOLUTION = 1000; // Check every second
         const DEVEL = false;
-        const IP_PATTERN = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/;
+        const IP_PATTERN = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/;
 
         $scope.loaded = Date.now();
         $scope.timerUptime= 0;
@@ -123,12 +123,12 @@ ngApp
                                 .then(function openDevToolsFrontend(json) {
                                     if (!json.data[0].devtoolsFrontendUrl) return callback(chrome.i18n.getMessage("errMsg7", [host, port]));
                                     var url = json.data[0].devtoolsFrontendUrl
-                                    var remoteIP = url.match(IP_PATTERN)[0];
+                                    var inspectIP = url.match(IP_PATTERN)[0];
                                     url = url
                                         .replace("localhost:9229", host + ":" + port) // When localhost is being used, set the given host and port
                                         .replace("localhost:" + port, host + ":" + port)  // A check for just the port change must be made.
-                                        .replace(remoteIP + ":9229", host + ":" + port) // In the event that remote debugging is being used and the infoUrl port (by default 80) is not forwarded.
-                                        .replace(remoteIP + ":" + port, host + ":" + port) // A check for just the port change must be made.
+                                        .replace(inspectIP + ":9229", host + ":" + port) // In the event that remote debugging is being used and the infoUrl port (by default 80) is not forwarded.
+                                        .replace(inspectIP + ":" + port, host + ":" + port) // A check for just the port change must be made.
                                     if ($scope.settings.localDevTools)
                                         url = url.replace('https://chrome-devtools-frontend.appspot.com', 'chrome-devtools://devtools/remote');
                                     var websocketId = json.data[0].id;


### PR DESCRIPTION
It's related to this issue #24 
so basically it will replace any given IP from remote host to localhost.

in my case, i use windows as host and ubuntu in my VM as client, with NAT as network adapter.
when i used port forwarding in the host, it always redirected to 10.0.2.15 (NAT IP).

Therefore, any matched IP (with IP_PATTERN) from url will be replaced to given host by this PR.
Thanks.